### PR TITLE
isort 명령어 실행 시 패키지로 범위 제한

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,5 +1,5 @@
 check:
-	isort --recursive --check-only
+	isort --recursive --check-only {{ cookiecutter.package_name }}
 {%- if cookiecutter.use_black|lower == 'y' %}
 	black -S -l 79 --check .
 {%- endif %}
@@ -9,7 +9,7 @@ check:
 {%- endif %}
 
 format:
-	isort -rc -y
+	isort -rc -y {{ cookiecutter.package_name }}
 {%- if cookiecutter.use_black|lower == 'y' %}
 	black -S -l 79 .
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/bin/pre-push
+++ b/{{cookiecutter.project_slug}}/bin/pre-push
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-isort --recursive --check-only
+isort --recursive --check-only {{ cookiecutter.package_name }}
 if [ $? -ne 0 ]; then
   echo "[!] isort failed! Run 'isort -rc -y'"
   exit 1


### PR DESCRIPTION
isort 명령어 실행 시 virtual environment 등 개발 환경에 따라 불필요한 내용까지 검사 범위에 포함되는 문제가 있습니다. 이를 해결하기 위해 `isort` 명령어 실행 시 생성된 패키지(`{{ cookiecutter.package_name }}`)로 검사 범위를 제한하도록 개선했습니다.