### PR TITLE
Fix black commands

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,7 +1,7 @@
 check:
-	isort --recursive --check-only {{ cookiecutter.package_name }}
+	isort --recursive --check-only {{ cookiecutter.package_name }} tests
 {%- if cookiecutter.use_black|lower == 'y' %}
-	black -S -l 79 --check {{ cookiecutter.package_name }}
+	black -S -l 79 --check {{ cookiecutter.package_name }} tests
 {%- endif %}
 	pylint {{ cookiecutter.package_name }}
 {%- if cookiecutter.use_mypy|lower != 'do not use' %}
@@ -9,9 +9,9 @@ check:
 {%- endif %}
 
 format:
-	isort -rc -y {{ cookiecutter.package_name }}
+	isort -rc -y {{ cookiecutter.package_name }} tests
 {%- if cookiecutter.use_black|lower == 'y' %}
-	black -S -l 79 {{ cookiecutter.package_name }}
+	black -S -l 79 {{ cookiecutter.package_name }} tests
 {%- endif %}
 
 test:

--- a/{{cookiecutter.project_slug}}/bin/pre-push
+++ b/{{cookiecutter.project_slug}}/bin/pre-push
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-isort --recursive --check-only {{ cookiecutter.package_name }}
+isort --recursive --check-only {{ cookiecutter.package_name }} tests
 if [ $? -ne 0 ]; then
-  echo "[!] isort failed! Run 'isort -rc -y {{ cookiecutter.package_name }}'"
+  echo "[!] isort failed! Run 'isort -rc -y {{ cookiecutter.package_name }} tests'"
   exit 1
 fi
 echo "[+] isort success!"
 
 {% if cookiecutter.use_black|lower == 'y' -%}
-black -S -l 79 --check {{ cookiecutter.package_name }}
+black -S -l 79 --check {{ cookiecutter.package_name }} tests
 if [ $? -ne 0 ]; then
-  echo "[!] black failed! Run 'black -S -l 79 {{ cookiecutter.package_name }}'"
+  echo "[!] black failed! Run 'black -S -l 79 {{ cookiecutter.package_name }} tests'"
   exit 1
 fi
 echo "[+] black success!"


### PR DESCRIPTION
- #13 와 비슷하게 `black` 명령어도 개발 환경에 따라 패키지 외 범위의 파일을 formatting하는 문제가 있습니다. 이에 따라 현재 디렉토리(`.`)가 아닌 특정 패키지(`{{ cookiecutter.pacakge_name }}`)를 실행 범위로 제한하는 걸 제안합니다.
- #13 변경에 따라 `isort` 명령어 실패 시 발생하는 메시지를 수정했습니다.