### PR TITLE
Travis URL 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rainist Python Project Template
 
-[![Build Status](https://badgen.net/travis/rainist/python)](https://travis-ci.com/Rainist/python)
+`[![Build Status](https://travis-ci.org/Rainist/python.svg?branch=master)](https://travis-ci.org/Rainist/python)`
 
 ## Usage
 


### PR DESCRIPTION
* root travis url을 변경합니다.
* rainist/rrn 레포로 테스트해봤을 때 공개 repo의 경우 `.com`, `.org` 모두 동작합니다.
* 일단 public repo라는 점을 들어 `.org`로 연결하였습니다.
* #9 해결