### PR TITLE
잘못된 도커 커맨드 수정

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -19,7 +19,7 @@ COPY requirements.txt .
 RUN pip wheel -r requirements.txt
 
 # Execution Stage
-FROM build
+FROM base
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
석찬님의 제보로 발견한 크리티컬한 오타입니다.
Production Stage 빌드는 build를 베이스로 하는게 아닌 base를 베이스로 진행되어야합니다.