### PR TITLE
의존성 업데이트

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,5 +1,5 @@
 {%- if cookiecutter.python_version == "3.7" -%}
-FROM python:3.7.2-alpine3.9 AS base
+FROM python:3.7.3-alpine3.9 AS base
 {%- else -%}
 FROM python:3.6.8-alpine3.9 AS base
 {%- endif %}

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 isort = "*"
 {%- if cookiecutter.use_black|lower != 'n' %}
-black = "*"
+black = "==19.3b0"
 {%- endif %}
 pylint = "*"
 {%- if cookiecutter.use_mypy|lower != 'do not use' %}

--- a/{{cookiecutter.project_slug}}/requirements-dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements-dev.txt
@@ -1,12 +1,12 @@
 {%- if cookiecutter.use_black|lower == 'y' -%}
-black==18.9b0
+black==19.3b0
 {% endif -%}
 {% if cookiecutter.use_mypy|lower != 'do not use' -%}
-mypy==0.670
+mypy==0.701
 {% endif -%}
 
 codecov==2.0.15
-isort==4.3.4
+isort==4.3.20
 pylint==2.3.1
-pytest==4.2.0
-pytest-cov==2.6.1
+pytest==4.6.3
+pytest-cov==2.7.1


### PR DESCRIPTION
Resolve #31

* Docker image python 버전을 3.7.3으로 업데이트 했습니다.
* `Pipfile`에 `black = "==19.3b0"` 처럼 프리릴리즈된 라이브러리 버전을 명시해 이제 `pipenv`를 사용할 때 `--pre` flag를 사용하라는 에러가 출력되지 않습니다.
* 기타 개발환경 라이브러리 버전을 업데이트했습니다.