### PR TITLE
Makefile, travis 개선

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 
 language: python
 
-dist:
-  - xenial
+dist: xenial
 
 python:
   - "3.7"

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -44,3 +44,17 @@ def test_makefile_total_section(cookies, context, black, pipenv, mypy):
     expected = 8
     expected -= 1 if pipenv == 'n' else 0
     assert len(sections) == expected
+
+
+@pytest.mark.parametrize('pipenv', ['y', 'n'])
+def test_makefile_phony(cookies, context, pipenv):
+    ctx = context(pipenv=pipenv)
+    result = cookies.bake(extra_context=ctx)
+
+    makefile = result.project.join('Makefile')
+    lines = makefile.readlines()
+    phony = lines[0]
+
+    expected = 8
+    expected -= 1 if pipenv == 'n' else 0
+    assert len(phony.split(' ')) == expected

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -26,4 +26,21 @@ def test_makefile_total_lines(cookies, context, black, pipenv, mypy):
     expected = 27
     expected -= 2 if black == 'n' else 0
     expected -= 1 if mypy == 'do not use' else 0
+    expected += 4 if pipenv == 'y' else 0
     assert len(lines) == expected
+
+
+@pytest.mark.parametrize('black', ['y', 'n'])
+@pytest.mark.parametrize('pipenv', ['y', 'n'])
+@pytest.mark.parametrize('mypy', ['do not use', 'beginner', 'expert'])
+def test_makefile_total_section(cookies, context, black, pipenv, mypy):
+    ctx = context(black=black, pipenv=pipenv, mypy=mypy)
+    result = cookies.bake(extra_context=ctx)
+
+    makefile = result.project.join('Makefile')
+    content = makefile.read()
+    sections = content.strip().split('\n\n')
+
+    expected = 8
+    expected -= 1 if pipenv == 'n' else 0
+    assert len(sections) == expected

--- a/tests/test_travis.py
+++ b/tests/test_travis.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.mark.parametrize('version', ['3.7', '3.6'])
+@pytest.mark.parametrize('pipenv', ['y', 'n'])
+def test_travis_total_lines(cookies, context, version, pipenv):
+    """
+    We expect .travis.yml has below content
+    ```
+    1 sudo: required
+    2
+    3 language: python
+    4
+    5 install:
+    6   - make
+    ```
+    """
+    ctx = context(version=version, pipenv=pipenv)
+    result = cookies.bake(extra_context=ctx)
+
+    makefile = result.project.join('.travis.yml')
+    lines = makefile.readlines(cr=False)
+
+    expected = 32
+    expected -= 2 if version == '3.6' else 0
+    expected -= 6 if pipenv == 'n' else 0
+    assert len(lines) == expected
+
+
+@pytest.mark.parametrize('version', ['3.7', '3.6'])
+@pytest.mark.parametrize('pipenv', ['y', 'n'])
+def test_travis_total_section(cookies, context, version, pipenv):
+    ctx = context(version=version, pipenv=pipenv)
+    result = cookies.bake(extra_context=ctx)
+
+    makefile = result.project.join('.travis.yml')
+    content = makefile.read()
+    sections = content.strip().split('\n\n')
+
+    expected = 10
+    expected -= 1 if version == '3.6' else 0
+    expected -= 1 if pipenv == 'n' else 0
+    assert len(sections) == expected

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -4,8 +4,7 @@ language: python
 
 {%- if cookiecutter.python_version == "3.7" %}
 
-dist:
-  - xenial
+dist: xenial
 {%- endif %}
 
 python:

--- a/{{cookiecutter.project_slug}}/.travis.yml
+++ b/{{cookiecutter.project_slug}}/.travis.yml
@@ -29,7 +29,6 @@ install:
   - make
 
 script:
-
 {%- if cookiecutter.use_pipenv|lower != 'n' %}
   - pipenv run make check
   - pipenv run make test
@@ -39,4 +38,9 @@ script:
 {%- endif %}
 
 after_success:
+{%- if cookiecutter.use_pipenv|lower != 'n' %}
+  - pipenv run make coverage
+{%- else %}
+  - make coverage
+{%- endif %}
   - bash < (curl -s https://codecov.io/bash)

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -35,3 +35,10 @@ htmlcov:
 	python -m pytest --cov {{ cookiecutter.package_name }} --cov-report html
 	rm -rf /tmp/htmlcov && mv htmlcov /tmp/
 	open /tmp/htmlcov/index.html
+
+{%- if cookiecutter.use_pipenv|lower != 'n' %}
+
+requirements:
+	pipenv lock -r > requirements.txt
+	pipenv lock -dr > requirements-dev.txt
+{%- endif %}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init check format test coverage htmlcov
+.PHONY: init check format test coverage htmlcov{% if cookiecutter.use_pipenv|lower != 'n' %} requirements{% endif %}
 
 init:
 {%- if cookiecutter.use_pipenv|lower != 'n' %}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -29,7 +29,7 @@ test:
 	python -m pytest
 
 coverage:
-	python -m pytest --cov {{ cookiecutter.package_name }} --cov-report term
+	python -m pytest --cov {{ cookiecutter.package_name }} --cov-report term --cov-report xml
 
 htmlcov:
 	python -m pytest --cov {{ cookiecutter.package_name }} --cov-report html

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -4,16 +4,16 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-isort = "*"
+isort = "4.3.20"
 {%- if cookiecutter.use_black|lower != 'n' %}
 black = "==19.3b0"
 {%- endif %}
-pylint = "*"
+pylint = "2.3.1"
 {%- if cookiecutter.use_mypy|lower != 'do not use' %}
-mypy = "*"
+mypy = "0.701"
 {%- endif %}
-pytest = "*"
-pytest-cov = "*"
+pytest = "4.6.3"
+pytest-cov = "2.7.1"
 
 [packages]
 


### PR DESCRIPTION
Resolve #32 

* `Makefile`에 `requirements`를 추가했습니다.
	* pipenv을 사용하지 않는 개발자와 협업할 경우 `requirements.txt` 등의 별도 파일이 필요한데 이를 생성하는 명령어입니다.
* 커버리지 리포트를 제대로 생성해 codecov에서 사용합니다.
	* `pytest --cov-report xml` 등이 없을 경우 `.travis.yml:after_success`의 codecov가 리포트를 인식하지 못합니다.
* `.travis.yml`의 `dist` 형태를 변경했습니다.
	* 기존 형태는 적합한 yaml 문법이긴 하나 vscode와 IntelliJ에서 `Value is not accepted. Valid values: "precise", "trusty", "xenial"` 오류를 발생시킵니다.
* 테스트를 강화했습니다.
	* `Makefile`, `.travis.yml`에서 라인 수 뿐만 아니라 덩어리(section)가 몇 개인지도 테스트합니다.
* `Pipfile`에 버전을 명시했습니다.
	* `Pipfile.lock`으로 관리하기엔 비용이 많이 들거라 예상되어 `Pipfile`에 명시해줬습니다.