### PR TITLE
누락된 구분자 추가

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -4,16 +4,16 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-isort = "4.3.20"
+isort = "==4.3.20"
 {%- if cookiecutter.use_black|lower != 'n' %}
 black = "==19.3b0"
 {%- endif %}
-pylint = "2.3.1"
+pylint = "==2.3.1"
 {%- if cookiecutter.use_mypy|lower != 'do not use' %}
-mypy = "0.701"
+mypy = "==0.701"
 {%- endif %}
-pytest = "4.6.3"
-pytest-cov = "2.7.1"
+pytest = "==4.6.3"
+pytest-cov = "==2.7.1"
 
 [packages]
 


### PR DESCRIPTION
Pipfile에 누락된 `==` 때문에 발생하던 `ValueError: Invalid Specifiers`에러를 해결합니다.