### PR TITLE
의존성 파일 테스트 추가

### DIFF
--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,70 @@
+from typing import List, Iterator
+
+import pytest
+
+
+@pytest.mark.parametrize('black', ['y', 'n'])
+@pytest.mark.parametrize('mypy', ['do not use', 'beginner', 'expert'])
+@pytest.mark.parametrize('requirements', ['requirements-dev.txt'])
+def test_requirements_include_specifiers(
+    cookies, context, black, mypy, requirements
+):
+    """
+    We expect each package has `==` specifier
+    ```
+    1 black==19.3b0
+    2 mypy==0.701
+    ```
+    """
+    ctx = context(black=black, mypy=mypy)
+    result = cookies.bake(extra_context=ctx)
+
+    packages = result.project.join(requirements)
+    content = packages.read()
+    lines = content.strip().split('\n')
+
+    assert all('==' in l for l in lines)
+
+
+@pytest.mark.parametrize('black', ['y', 'n'])
+@pytest.mark.parametrize('mypy', ['do not use', 'beginner', 'expert'])
+@pytest.mark.parametrize('packages', ['[dev-packages]'])
+def test_pipfile_include_specifiers(cookies, context, black, mypy, packages):
+    """
+    We expect each package has `==` specifier
+    ```
+    1 [dev-packages]
+    2 isort = "==4.3.20"
+    3 black = "==19.3b0"
+    4
+    5 [packages]
+    6 sanic = "==19.6.0"
+    ```
+    """
+    ctx = context(black=black, mypy=mypy, pipenv='y')
+    result = cookies.bake(extra_context=ctx)
+
+    pipfile = result.project.join('Pipfile')
+    content = pipfile.read()
+    sections = content.strip().split('\n\n')
+    lines = filter(
+        is_pipfile_requirement, split_section_to_lines(sections, packages)
+    )
+
+    assert all('==' in l for l in lines)
+
+
+def split_section_to_lines(sections: List[str], title: str) -> Iterator[str]:
+    for s in sections:
+        if title in s:
+            yield from s.split('\n')
+
+
+def is_pipfile_requirement(line: str) -> bool:
+    """
+    >>> is_pipfile_requirement('isort = "==4.3.20"')
+    True
+    >>> is_pipfile_requirement('[dev-packages]')
+    False
+    """
+    return len(line.split(' ')) == 3 and '=' in line


### PR DESCRIPTION
`requirements-dev.txt`와 `Pipfile`의 테스트를 추가했습니다.
각 의존성이 특정한 버전으로 명시되어있는지 검증합니다. (`==`가 있는지 검사)
일단 저희가 `^, ~, >=`등의 specifier는 사용하지 않기에 제외했고 사용하게 될 때 테스트가 터질테니 그 때 테스트 케이스를 수정하면 될 듯 합니다