### PR TITLE
Fix mypy version

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -10,7 +10,7 @@ black = "==19.3b0"
 {%- endif %}
 pylint = "==2.3.1"
 {%- if cookiecutter.use_mypy|lower != 'do not use' %}
-mypy = "==0.701"
+mypy = "==0.730"
 {%- endif %}
 pytest = "==4.6.3"
 pytest-cov = "==2.7.1"

--- a/{{cookiecutter.project_slug}}/requirements-dev.txt
+++ b/{{cookiecutter.project_slug}}/requirements-dev.txt
@@ -2,7 +2,7 @@
 black==19.3b0
 {% endif -%}
 {% if cookiecutter.use_mypy|lower != 'do not use' -%}
-mypy==0.701
+mypy==0.730
 {% endif -%}
 
 codecov==2.0.15


### PR DESCRIPTION
**라이브러리 의존성 깨짐 오류 해결**

현재 python `3.7.3`, `3.7.4` 기준으로 아래와 같이 라이브러리 dependency 오류가 발생하고 있습니다. 
```
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  First try clearing your dependency cache with $ pipenv lock --clear, then try the original command again.
 Alternatively, you can use $ pipenv install --skip-lock to bypass this mechanism, then run $ pipenv graph to inspect the situation.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: ERROR: Could not find a version that matches typed-ast<1.4.0,<1.5,>=1.3.1,>=1.4.0
```

`mypy = "==0.701"` -> `mypy = "==0.730"` mypy 버전을 최신 버전으로 변경했습니다.
(http://mypy-lang.blogspot.com/2019/09/mypy-730-released.html)
