### PR TITLE
Add help command to Makefile

### DIFF
--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -11,14 +11,16 @@ def test_makefile_total_lines(cookies, context, black, pipenv, mypy):
     We expect Makefile has below content
     ```
     1 .PHONY: check
-    2 check:
-    3     isort
-    4     black
-    5
-    6 .PHONY: format
-    7 format:
-    8     isort
-    9     black
+    2 ## check: check if everything's okay
+    3 check:
+    4     isort
+    5     black
+    6
+    7 .PHONY: format
+    8 ## format: format files
+    9 format:
+    10     isort
+    11     black
     ```
     """
     ctx = context(black=black, pipenv=pipenv, mypy=mypy)
@@ -27,10 +29,10 @@ def test_makefile_total_lines(cookies, context, black, pipenv, mypy):
     makefile = result.project.join('Makefile')
     lines = makefile.readlines(cr=False)
 
-    expected = 31
+    expected = 43
     expected -= 2 if black == 'n' else 0
     expected -= 1 if mypy == 'do not use' else 0
-    expected += 5 if pipenv == 'y' else 0
+    expected += 6 if pipenv == 'y' else 0
     assert len(lines) == expected
 
 
@@ -45,8 +47,8 @@ def test_makefile_total_section(cookies, context, black, pipenv, mypy):
     content = makefile.read()
     sections = content.strip().split('\n\n')
 
-    expected = 7
-    expected -= 1 if pipenv == 'n' else 0
+    expected = 8  # init,check,format,test,coverage,htmlcov,requirements,help
+    expected -= 1 if pipenv == 'n' else 0  # requirements
     assert len(sections) == expected
 
 
@@ -59,6 +61,6 @@ def test_makefile_phony(cookies, context, pipenv):
 
     phonies = re.findall(r'\.PHONY: (\w+)', makefile.read())
 
-    expected = 7
-    expected -= 1 if pipenv == 'n' else 0
+    expected = 8  # init,check,format,test,coverage,htmlcov,requirements,help
+    expected -= 1 if pipenv == 'n' else 0  # requirements
     assert len(set(phonies)) == expected

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,4 +1,5 @@
 .PHONY: init
+## init: install requirements
 init:
 {%- if cookiecutter.use_pipenv|lower != 'n' %}
 	pip install pipenv
@@ -9,6 +10,7 @@ init:
 {%- endif %}
 
 .PHONY: check
+## check: check if everything's okay
 check:
 	isort --recursive --check-only {{ cookiecutter.package_name }} tests
 {%- if cookiecutter.use_black|lower != 'n' %}
@@ -20,6 +22,7 @@ check:
 {%- endif %}
 
 .PHONY: format
+## format: format files
 format:
 	isort -rc -y {{ cookiecutter.package_name }} tests
 {%- if cookiecutter.use_black|lower != 'n' %}
@@ -27,14 +30,17 @@ format:
 {%- endif %}
 
 .PHONY: test
+## test: run tests
 test:
 	python -m pytest
 
 .PHONY: coverage
+## coverage: run tests with coverage
 coverage:
 	python -m pytest --cov {{ cookiecutter.package_name }} --cov-report term --cov-report xml
 
 .PHONY: htmlcov
+## htmlcov: run tests with coverage and create coverage report HTML files
 htmlcov:
 	python -m pytest --cov {{ cookiecutter.package_name }} --cov-report html
 	rm -rf /tmp/htmlcov && mv htmlcov /tmp/
@@ -43,7 +49,14 @@ htmlcov:
 {%- if cookiecutter.use_pipenv|lower != 'n' %}
 
 .PHONY: requirements
+## requirements: update requirements.txt
 requirements:
 	pipenv lock -r > requirements.txt
 	pipenv lock -dr > requirements-dev.txt
 {%- endif %}
+
+.PHONY: help
+## help: prints this help message
+help:
+	@echo "Usage: \n"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':'


### PR DESCRIPTION
After reading [this article](https://danishpraka.sh/2019/12/07/using-makefiles-for-go.html), I guessed `help command` would be helpful. I just added some comments for each command and add `help` command. `make help` would print out the following result:
```
$ make help
Usage: 

 init           install requirements
 check          check if everything's okay
 format         format files
 test           run tests
 coverage       run tests with coverage
 htmlcov        run tests with coverage and create coverage report HTML files
 requirements   update requirements.txt
 help           prints this help message
```
